### PR TITLE
Document the "backend" keyword in the db credential example.

### DIFF
--- a/example/config/db.credentials.example
+++ b/example/config/db.credentials.example
@@ -2,5 +2,6 @@
     "user": "[dbuser]",
     "password": "[64byte hex]",
     "host": "[host]",
-    "port": "[port]"
+    "port": "[port]",
+    "backend": "django.db.backends.[postgresql_psycopg2 or postgresql (default if line ommitted: postgresql)]"
 }


### PR DESCRIPTION
 This is required in Ubuntu 16, when installing psycopg2.